### PR TITLE
Fix include in BTooth.cpp

### DIFF
--- a/Bluetti_ESP32/BTooth.cpp
+++ b/Bluetti_ESP32/BTooth.cpp
@@ -1,5 +1,5 @@
 #include "BluettiConfig.h"
-#include "Btooth.h"
+#include "BTooth.h"
 #include "utils.h"
 #include "PayloadParser.h"
 #include "BWifi.h"


### PR DESCRIPTION
Change the include of BTooth.h to the actual file name. 

Without that change the project didn't compile for me..