### PR TITLE
Add some device sleep time when bluetooth connection is not available

### DIFF
--- a/Bluetti_ESP32/BTooth.cpp
+++ b/Bluetti_ESP32/BTooth.cpp
@@ -206,7 +206,11 @@ void handleBluetooth(){
 
   if ((millis() - lastBTMessage) > (MAX_DISCONNECTED_TIME_UNTIL_REBOOT * 60000)){ 
     Serial.println(F("BT is disconnected over allowed limit, reboot device"));
-    ESP.restart();
+    #ifdef SLEEP_TIME_ON_BT_NOT_AVAIL
+        esp_deep_sleep_start();
+    #else
+        ESP.restart();
+    #endif
   }
 
   if (connected) {

--- a/Bluetti_ESP32/Bluetti_ESP32.ino
+++ b/Bluetti_ESP32/Bluetti_ESP32.ino
@@ -12,6 +12,9 @@ void setup() {
     #endif
     digitalWrite(RELAIS_PIN, RELAIS_LOW);
   #endif
+  #ifdef SLEEP_TIME_ON_BT_NOT_AVAIL
+    esp_sleep_enable_timer_wakeup(SLEEP_TIME_ON_BT_NOT_AVAIL * 60 * 1000000ULL);
+  #endif
   initBWifi(false);
   initBluetooth();
   initMQTT();

--- a/Bluetti_ESP32/config.h
+++ b/Bluetti_ESP32/config.h
@@ -18,6 +18,8 @@
 #define RELAIS_HIGH HIGH
 
 #define MAX_DISCONNECTED_TIME_UNTIL_REBOOT 2 //device will reboot when wlan/BT/MQTT is not connectet within x Minutes
+#define SLEEP_TIME_ON_BT_NOT_AVAIL 2 //device will sleep x minutes if restarted is triggered by bluetooth error
+                                     //set to 0 to disable
 
 #ifndef BLUETTI_TYPE
   #define BLUETTI_TYPE BLUETTI_AC300


### PR DESCRIPTION
When the bluetti device turns off, the esp currently keeps restarting because it can't establish connection. Add some sleep time to these restarts to save some energy. Its not a lot, but its basically for free...