### PR TITLE
one poll command, including ac/dc status

### DIFF
--- a/Bluetti_ESP32/DEVICE_EB3A.h
+++ b/Bluetti_ESP32/DEVICE_EB3A.h
@@ -62,9 +62,12 @@ static device_field_data_t bluetti_device_command[] = {
 };
 
 static device_field_data_t bluetti_polling_command[] = {
-  {FIELD_UNDEFINED, 0x00, 0x0A, 0x28 ,0 , 0, TYPE_UNDEFINED},
-  {FIELD_UNDEFINED, 0x00, 0x46, 0x15 ,0 , 0, TYPE_UNDEFINED},
-  {FIELD_UNDEFINED, 0x0B, 0xB9, 0x3D ,0 , 0, TYPE_UNDEFINED}
+  // this one request is sufficient to get all the currently transmitted data
+  // raising length by 2 also reads the state of ac/dc switches 
+  {FIELD_UNDEFINED, 0x00, 0x0A, 0x2A ,0 , 0, TYPE_UNDEFINED}
+  //,
+  //{FIELD_UNDEFINED, 0x00, 0x46, 0x15 ,0 , 0, TYPE_UNDEFINED},
+  //{FIELD_UNDEFINED, 0x0B, 0xB9, 0x3D ,0 , 0, TYPE_UNDEFINED}
 };
 
 #endif


### PR DESCRIPTION
currently, the first poll command already reads all data submitted to MQTT server
increasing the requested length by 2 adds the status of ac/dc switches to the data submitted to MQTT server
