### PR TITLE
Support No MQTT Server

### DIFF
--- a/Bluetti_ESP32/BWifi.cpp
+++ b/Bluetti_ESP32/BWifi.cpp
@@ -199,7 +199,12 @@ String processorWebsiteUpdates(const String& var){
   }
   else if(var == "MQTT_IP"){
     char msg[40];
-    strlcpy(msg, wifiConfig.mqtt_server, 40);
+    if (strlen(wifiConfig.mqtt_server) == 0){
+      strlcpy(msg, "No MQTT server configured", 40);
+    }else{
+      strlcpy(msg, wifiConfig.mqtt_server, 40);
+    }
+    
     return msg;
   }
   else if(var == "MQTT_PORT"){

--- a/Bluetti_ESP32/MQTT.cpp
+++ b/Bluetti_ESP32/MQTT.cpp
@@ -123,6 +123,7 @@ void subscribeTopic(enum field_names field_name) {
 
 void publishTopic(enum field_names field_name, String value){
   char publishTopicBuf[1024];
+  ESPBluettiSettings settings = get_esp32_bluetti_settings();
  
 #ifdef DEBUG
   Serial.println("publish topic for field: " +  map_field_name(field_name));
@@ -135,18 +136,20 @@ void publishTopic(enum field_names field_name, String value){
     ESP.restart();
    
   } 
-
-  ESPBluettiSettings settings = get_esp32_bluetti_settings();
-  sprintf(publishTopicBuf, "bluetti/%s/state/%s", settings.bluetti_device_id, map_field_name(field_name).c_str() ); 
-  lastMQTTMessage = millis();
-  if (!client.publish(publishTopicBuf, value.c_str() )){
-    publishErrorCount++;
-    AddtoMsgView(String(lastMQTTMessage) + ": publish ERROR! " + map_field_name(field_name) + " -> " + value);
-  }
-  else{
-    AddtoMsgView(String(lastMQTTMessage) + ": " + map_field_name(field_name) + " -> " + value);
-  }
   
+  sprintf(publishTopicBuf, "bluetti/%s/state/%s", settings.bluetti_device_id, map_field_name(field_name).c_str() ); 
+  if (strlen(settings.mqtt_server) == 0){
+    AddtoMsgView(String(millis()) +": " + map_field_name(field_name) + " -> " + value); 
+  }else{
+    lastMQTTMessage = millis();
+    if (!client.publish(publishTopicBuf, value.c_str() )){
+      publishErrorCount++;
+      AddtoMsgView(String(lastMQTTMessage) + ": publish ERROR! " + map_field_name(field_name) + " -> " + value);
+    }
+    else{
+      AddtoMsgView(String(lastMQTTMessage) + ": " + map_field_name(field_name) + " -> " + value);
+    }
+  }
   
  
 }
@@ -169,6 +172,10 @@ void initMQTT(){
 
     enum field_names f_name;
     ESPBluettiSettings settings = get_esp32_bluetti_settings();
+    if (strlen(settings.mqtt_server) == 0){
+      Serial.println("No MQTT server configured");
+      return;
+    }
     Serial.print("Connecting to MQTT at: ");
     Serial.print(settings.mqtt_server);
     Serial.print(":");
@@ -202,6 +209,10 @@ void initMQTT(){
 };
 
 void handleMQTT(){
+    ESPBluettiSettings settings = get_esp32_bluetti_settings();
+    if (strlen(settings.mqtt_server) == 0){
+      return;
+    }
     if ((millis() - lastMQTTMessage) > (MAX_DISCONNECTED_TIME_UNTIL_REBOOT * 60000)){ 
       Serial.println(F("MQTT is disconnected over allowed limit, reboot device"));
       ESP.restart();


### PR DESCRIPTION
Just a quick change so that you can specify blank as the mqtt server and the ESP32 doesn't restart every X minutes.

I primarily use the web interface and don't plan to have a server with a Mqtt broker (others might find it useful for testing without pushing data to the server)