### PR TITLE
More commands for eb3a

### DIFF
--- a/Bluetti_ESP32/BTooth.cpp
+++ b/Bluetti_ESP32/BTooth.cpp
@@ -47,7 +47,7 @@ class BluettiAdvertisedDeviceCallbacks: public BLEAdvertisedDeviceCallbacks {
 
      ESPBluettiSettings settings = get_esp32_bluetti_settings();
     // We have found a device, let us now see if it contains the service we are looking for.
-    if (advertisedDevice.haveServiceUUID() && advertisedDevice.isAdvertisingService(serviceUUID) && advertisedDevice.getName().compare(settings.bluetti_device_id)) {
+    if (advertisedDevice.haveServiceUUID() && advertisedDevice.isAdvertisingService(serviceUUID) && (strcmp(advertisedDevice.getName().c_str(),settings.bluetti_device_id)==0) ) {
       BLEDevice::getScan()->stop();
       bluettiDevice = new BLEAdvertisedDevice(advertisedDevice);
       doConnect = true;
@@ -96,7 +96,7 @@ static void notifyCallback(
 
     bt_command_t command_handle;
     if(xQueueReceive(commandHandleQueue, &command_handle, 500)){
-      pase_bluetooth_data(command_handle.page, command_handle.offset, pData, length);
+      parse_bluetooth_data(command_handle.page, command_handle.offset, pData, length);
     }
    
 }

--- a/Bluetti_ESP32/DEVICE_EB3A.h
+++ b/Bluetti_ESP32/DEVICE_EB3A.h
@@ -3,6 +3,7 @@
 #include "Arduino.h"
 
 /* Not implemented yet
+//Need to check which additional functions on EB3A are supported
 enum output_mode {
     STOP = 0,
     INVERTER_OUTPUT = 1,
@@ -26,6 +27,26 @@ enum auto_sleep_mode {
 };
 */
 
+enum LedMode {
+    LED_LOW = 1,
+    LED_HIGH = 2,
+    LED_SOS = 3,
+    LED_OFF = 4  
+};
+
+enum EcoShutdown {
+    ONE_HOUR = 1,
+    TWO_HOURS = 2,
+    THREE_HOURS = 3,
+    FOUR_HOURS = 4
+};
+
+enum ChargingMode {
+   STANDARD = 0,
+    SILENT = 1,
+    TURBO = 2
+};
+
 // { FIELD_NAME, PAGE, OFFSET, SIZE, SCALE (if scale is needed e.g. decimal value, defaults to 0) , ENUM (if data is enum, defaults to 0) , FIELD_TYPE }
 static device_field_data_t bluetti_device_state[] = {
   /*Page 0x00 Core */
@@ -42,29 +63,45 @@ static device_field_data_t bluetti_device_state[] = {
   {AC_OUTPUT_ON,      0x00, 0x30, 1, 0, 0, BOOL_FIELD},
   {DC_OUTPUT_ON,      0x00, 0x31, 1, 0, 0, BOOL_FIELD},
 
-  /*Page 0x00 Details 
-  {INTERNAL_AC_VOLTAGE,       0x00, 0x47, 1, 1, 0, DECIMAL_FIELD},
-  {INTERNAL_CURRENT_ONE,      0x00, 0x48, 1, 1, 0, DECIMAL_FIELD},
+  //Page 0x00 Details 
+  //{INTERNAL_AC_VOLTAGE,       0x00, 0x47, 1, 1, 0, DECIMAL_FIELD},
+  //{INTERNAL_CURRENT_ONE,      0x00, 0x48, 1, 1, 0, DECIMAL_FIELD},
+  {AC_INPUT_VOLTAGE,            0x00, 0x4D, 1, 1, 0, DECIMAL_FIELD},
+  {INTERNAL_DC_INPUT_VOLTAGE,   0x00, 0x56, 1, 1, 0, DECIMAL_FIELD},
 
   //Page 0x00 Battery Details
   {PACK_NUM_MAX, 0x00, 0x5B, 1, 0, 0, UINT_FIELD },
 
   //Page 0x00 Battery Data 
-  {PACK_VOLTAGE, 0x00, 0x62, 1, 2 ,0 ,DECIMAL_FIELD},
-  */
+  //{PACK_VOLTAGE, 0x00, 0x62, 1, 2 ,0 ,DECIMAL_FIELD},
   
 };
 
 static device_field_data_t bluetti_device_command[] = {
   /*Page 0x00 Core */
   {AC_OUTPUT_ON,      0x0B, 0xBF, 1, 0, 0, BOOL_FIELD}, 
-  {DC_OUTPUT_ON,      0x0B, 0xC0, 1, 0, 0, BOOL_FIELD}
+  {DC_OUTPUT_ON,      0x0B, 0xC0, 1, 0, 0, BOOL_FIELD},
+  {LED_MODE,          0x0B, 0xDA, 1, 0, 0, ENUM_FIELD},
+  {POWER_OFF,         0x0B, 0xF4, 1, 0, 0, BOOL_FIELD},
+  {ECO_ON,            0x0B, 0xF7, 1, 0, 0, BOOL_FIELD},
+  {ECO_SHUTDOWN,      0x0B, 0xF8, 1, 0, 0, ENUM_FIELD}, 
+  {CHARGING_MODE,     0x0B, 0xF9, 1, 0, 0, ENUM_FIELD},
+  {POWER_LIFTING_ON,  0x0B, 0xFA, 1, 0, 0, BOOL_FIELD},
 };
 
 static device_field_data_t bluetti_polling_command[] = {
   {FIELD_UNDEFINED, 0x00, 0x0A, 0x28 ,0 , 0, TYPE_UNDEFINED},
   {FIELD_UNDEFINED, 0x00, 0x46, 0x15 ,0 , 0, TYPE_UNDEFINED},
-  {FIELD_UNDEFINED, 0x0B, 0xB9, 0x3D ,0 , 0, TYPE_UNDEFINED}
+  {FIELD_UNDEFINED, 0x0B, 0xDA, 0x01 ,0 , 0, TYPE_UNDEFINED},
+  {FIELD_UNDEFINED, 0x0B, 0xF4, 0x07 ,0 , 0, TYPE_UNDEFINED},
+};
+
+static device_field_data_t bluetti_logging_command[] = {
+  {FIELD_UNDEFINED, 0x00, 0x0A, 0x35 ,0 , 0, TYPE_UNDEFINED},
+  {FIELD_UNDEFINED, 0x00, 0x46, 0x42 ,0 , 0, TYPE_UNDEFINED},
+  {FIELD_UNDEFINED, 0x00, 0x88, 0x4A ,0 , 0, TYPE_UNDEFINED},
+  {FIELD_UNDEFINED, 0x0B, 0xB8, 0x43 ,0 , 0, TYPE_UNDEFINED}
+
 };
 
 #endif

--- a/Bluetti_ESP32/DEVICE_EB3A.h
+++ b/Bluetti_ESP32/DEVICE_EB3A.h
@@ -42,7 +42,7 @@ enum EcoShutdown {
 };
 
 enum ChargingMode {
-   STANDARD = 0,
+    STANDARD = 0,
     SILENT = 1,
     TURBO = 2
 };

--- a/Bluetti_ESP32/DeviceType.h
+++ b/Bluetti_ESP32/DeviceType.h
@@ -23,7 +23,8 @@ enum field_names {
   TOTAL_BATTERY_PERCENT, 
   DC_INPUT_POWER,
   AC_INPUT_POWER,
-  PACK_VOLTAGE,
+  AC_INPUT_VOLTAGE,
+  INTERNAL_PACK_VOLTAGE,
   SERIAL_NUMBER,
   ARM_VERSION,
   DSP_VERSION,
@@ -33,8 +34,16 @@ enum field_names {
   GRID_CHANGE_ON,
   FIELD_UNDEFINED,
   INTERNAL_AC_VOLTAGE,
+  INTERNAL_AC_FREQUENCY,
   INTERNAL_CURRENT_ONE,
-  PACK_NUM_MAX
+  PACK_NUM_MAX,
+  INTERNAL_DC_INPUT_VOLTAGE,
+  LED_MODE,
+  POWER_OFF,
+  ECO_ON,
+  ECO_SHUTDOWN,
+  CHARGING_MODE,
+  POWER_LIFTING_ON
 };
 
 typedef struct device_field_data {
@@ -46,6 +55,5 @@ typedef struct device_field_data {
   int8_t f_enum;
   enum field_types f_type;
 } device_field_data_t;
-
 
 #endif

--- a/Bluetti_ESP32/MQTT.cpp
+++ b/Bluetti_ESP32/MQTT.cpp
@@ -107,10 +107,78 @@ String map_field_name(enum field_names f_name){
   
 }
 
+//There is no reflection to do string to enum
+//There are a couple of ways to work aroung it... but basically are just "case" statements
+//Wapped them in a fuction
+String map_command_value(String command_name, String value){
+  String toRet = value;
+  value.toUpperCase();
+  command_name.toUpperCase(); //force case indipendence
+
+  //on / off commands
+  if(command_name == "POWER_OFF" || command_name == "AC_OUTPUT_ON" || command_name == "DC_OUTPUT_ON" || command_name == "ECO_ON" || command_name == "POWER_LIFTING_ON") {
+    if (value == "ON") {
+      toRet = "1";
+    }
+    if (value == "OFF") {
+      toRet = "0";
+    }
+  }
+
+  //See DEVICE_EB3A enums
+  if(command_name == "LED_MODE"){
+    if (value == "LED_LOW") {
+      toRet = "1";
+    }
+    if (value == "LED_HIGH") {
+      toRet = "2";
+    }
+    if (value == "LED_SOS") {
+      toRet = "3";
+    }
+    if (value == "LED_OFF") {
+      toRet = "4";
+    }
+  }
+
+  //See DEVICE_EB3A enums
+  if(command_name == "ECO_SHUTDOWN"){
+    if (value == "ONE_HOUR") {
+      toRet = "1";
+    }
+    if (value == "TWO_HOURS") {
+      toRet = "2";
+    }
+    if (value == "THREE_HOURS") {
+      toRet = "3";
+    }
+    if (value == "FOUR_HOURS") {
+      toRet = "4";
+    }
+  }
+
+  //See DEVICE_EB3A enums
+  if(command_name == "CHARGING_MODE"){
+    if (value == "STANDARD") {
+      toRet = "0";
+    }
+    if (value == "SILENT") {
+      toRet = "1";
+    }
+    if (value == "TURBO") {
+      toRet = "2";
+    }
+  }
+
+
+  return toRet;
+}
+
 // Callback function
 void callback(char* topic, byte* payload, unsigned int length) {
   payload[length] = '\0';
   String topic_path = String(topic);
+  topic_path.toLowerCase();//in case we recieve DC_OUTPUT_ON instead of the expected dc_output_on
   
   Serial.print("MQTT Message arrived on topic: ");
   Serial.print(topic);
@@ -127,85 +195,8 @@ void callback(char* topic, byte* payload, unsigned int length) {
             command.page = bluetti_device_command[i].f_page;
             command.offset = bluetti_device_command[i].f_offset;
             
-            //Quick&Dirty (FIXME): map ON, OFF, LOW, HIGH, SOS, ... to numeric values for the command to send by BL
-            //e.g. for "power_off" from "ON" to "1"
 			      String current_name = map_field_name(bluetti_device_command[i].f_name);
-            if(current_name == "power_off") {
-                  if (strPayload == "ON") {
-                    strPayload = "1";
-                  }
-            } 
-            else if(current_name == "led_mode") {
-                  if (strPayload == "LED_LOW") {
-                    strPayload = "1";
-                  }
-                  else if (strPayload == "LED_HIGH") {
-                    strPayload = "2";
-                  }
-                  else if (strPayload == "LED_SOS") {
-                    strPayload = "3";
-                  }
-                  else if (strPayload == "LED_OFF") {
-                    strPayload = "4";
-                  }
-            } 
-            else if(current_name == "eco_shutdown") {
-                  if (strPayload == "ONE_HOUR") {
-                    strPayload = "1";
-                  }
-                  else if (strPayload == "TWO_HOURS") {
-                    strPayload = "2";
-                  }
-                  else if (strPayload == "THREE_HOURS") {
-                    strPayload = "3";
-                  }
-                  else if (strPayload == "FOUR_HOURS") {
-                    strPayload = "4";
-                  }
-            } 
-            else if(current_name == "charging_mode") {
-                  if (strPayload == "STANDARD") {
-                    strPayload = "0";
-                  }
-                  else if (strPayload == "SILENT") {
-                    strPayload = "1";
-                  }
-                  else if (strPayload == "TURBO") {
-                    strPayload = "2";
-                  }
-			      }
-            else if(current_name == "ac_output_on") {
-                  if (strPayload == "ON") {
-                    strPayload = "1";
-                  }
-                  else if (strPayload == "OFF") {
-                    strPayload = "0";
-                  }
-            }
-            else if(current_name == "dc_output_on") {
-                  if (strPayload == "ON") {
-                    strPayload = "1";
-                  }
-                  else if (strPayload == "OFF") {
-                    strPayload = "0";
-                  }
-            }
-            else if(current_name == "eco_on") {
-                  if (strPayload == "ON") {
-                    strPayload = "1";
-                  }
-                  else if (strPayload == "OFF") {
-                    strPayload = "0";
-                  }
-            }
-            else if(current_name == "power_lifting_on") {
-                  if (strPayload == "ON") {
-                    strPayload = "1";
-                  }
-                  else if (strPayload == "OFF") {
-                    strPayload = "0";
-                  }
-            }
+            strPayload = map_command_value(current_name,strPayload);
     }
   }
   Serial.print(" Payload - switched: ");

--- a/Bluetti_ESP32/MQTT.h
+++ b/Bluetti_ESP32/MQTT.h
@@ -4,12 +4,18 @@
 #include "DeviceType.h"
 
 extern void publishTopic(enum field_names field_name, String value);
+extern void publishHAConfig();
 extern void publishDeviceState();
+extern void publishDeviceStateStatus();
+extern void deviceServoPress(int degree);
 extern void handleMQTT();
+//TODO: for Command test with no mqtt
+extern void callback_str(char* topic, String strPayload, unsigned int length);
 extern void initMQTT();
 extern bool isMQTTconnected();
 extern int getPublishErrorCount();
 unsigned long getLastMQTTMessageTime();
-unsigned long getLastMQTDeviceStateMessageTime();
+unsigned long getLastMQTTDeviceStateMessageTime();
+unsigned long getLastMQTTDeviceStateStatusMessageTime();
 
 #endif

--- a/Bluetti_ESP32/MQTT.h
+++ b/Bluetti_ESP32/MQTT.h
@@ -9,8 +9,6 @@ extern void publishDeviceState();
 extern void publishDeviceStateStatus();
 extern void deviceServoPress(int degree);
 extern void handleMQTT();
-//TODO: for Command test with no mqtt
-extern void callback_str(char* topic, String strPayload, unsigned int length);
 extern void initMQTT();
 extern bool isMQTTconnected();
 extern int getPublishErrorCount();

--- a/Bluetti_ESP32/PayloadParser.h
+++ b/Bluetti_ESP32/PayloadParser.h
@@ -8,12 +8,12 @@
 
 uint16_t parse_uint_field(uint8_t data[]);
 bool parse_bool_field(uint8_t data[]);
-float pase_decimal_field(uint8_t data[], uint8_t scale);
+float parse_decimal_field(uint8_t data[], uint8_t scale);
 uint64_t parse_serial_field(uint8_t data[]);
 float parse_version_field(uint8_t data[]);
 String parse_string_field(uint8_t data[]);
-String pase_enum_field(uint8_t data[]);
+String parse_enum_field(uint8_t data[]);
 
-extern void pase_bluetooth_data(uint8_t page, uint8_t offset, uint8_t* pData, size_t length);
+extern void parse_bluetooth_data(uint8_t page, uint8_t offset, uint8_t* pData, size_t length);
 
 #endif

--- a/Bluetti_ESP32/PowerStation.h
+++ b/Bluetti_ESP32/PowerStation.h
@@ -10,6 +10,6 @@
 #define EP500P          5
 #define AC500           6
 
-#define POWER_STATION(type) (BLUETTI_TYPE==BLUETTI_##type)
+#define POWER_STATION(type) (BLUETTI_TYPE==type)
 
 #endif

--- a/Bluetti_ESP32/config.h
+++ b/Bluetti_ESP32/config.h
@@ -21,11 +21,12 @@
 #define SLEEP_TIME_ON_BT_NOT_AVAIL 2 //device will sleep x minutes if restarted is triggered by bluetooth error
                                      //set to 0 to disable
 #define DEVICE_STATE_UPDATE  5
+#define DEVICE_STATE_STATUS_UPDATE  2.5 //Was 0.5 in original branc which is half the DEVICE_STATE_UPDATE value, kept the ratio
 #define MSG_VIEWER_ENTRY_COUNT 20 //number of lines for web message viewer
 #define MSG_VIEWER_REFRESH_CYCLE 5 //refresh time for website data in seconds
 
 #ifndef BLUETTI_TYPE
-  #define BLUETTI_TYPE BLUETTI_AC300
+  #define BLUETTI_TYPE AC300
 #endif
 
 


### PR DESCRIPTION
Related to #42 , based on the extensive work done by @giovanne123 in the repository https://github.com/giovanne123/EB3A_Bluetti_ESP32_HA

- Added enums for ledMode, EcoShotDown and ChargingMode
- Updated bluetti_device state, command, polling and logging addresses
- Updated field_names
- Added device state statuses
- Added map_command_value
-- simplest way to get the enum value is a switch in C++, maps and other ways are available but still requires manual mapping
-- moded the original "quick&dirty" ifs from the callback function to a map_field_name style function

Additionally, changed POWER_STATION to check the device enum value directly without the BLUETTI_## prefix
- with the prefix seemed like only AC Device_AC300.h was compiled/loaded in VSCode even when the config.h param was changed to BLUETTI_EB3A
- with direct enum right device file is compile/loaded