### PR TITLE
arduino.h will only work with capital letter

### DIFF
--- a/Bluetti_ESP32/display.cpp
+++ b/Bluetti_ESP32/display.cpp
@@ -1,4 +1,4 @@
-#include <arduino.h>
+#include <Arduino.h>
 #include <Wire.h>
 #include <Adafruit_GFX.h>
 #include <Adafruit_SSD1306.h>

--- a/Bluetti_ESP32/display.h
+++ b/Bluetti_ESP32/display.h
@@ -22,4 +22,4 @@ void disp_setWifiSignal(int extWifMode=0, int extSignal=-100);
 void disp_setStatus(String strStatus);
 void disp_setIP(String strIP);
 #endif
-#include <arduino.h>
+#include <Arduino.h>


### PR DESCRIPTION
For some reason the arduino.h is not found with lower case. I am on a raspberry with raspbian.