### PR TITLE
replace deprecated AsyncElegantOTA

### DIFF
--- a/Bluetti_ESP32/BWifi.cpp
+++ b/Bluetti_ESP32/BWifi.cpp
@@ -8,7 +8,7 @@
 #include <ESPAsyncWebServer.h> // https://github.com/me-no-dev/ESPAsyncWebServer/archive/master.zip
 #include <AsyncTCP.h> // https://github.com/me-no-dev/AsyncTCP/archive/master.zip
 #include <ESPmDNS.h>
-#include <AsyncElegantOTA.h> // https://github.com/ayushsharma82/AsyncElegantOTA/archive/master.zip
+#include <ElegantOTA.h> // https://github.com/ayushsharma82/ElegantOTA/archive/master.zip
 #include "display.h"
 
 AsyncWebServer server(80);
@@ -194,9 +194,9 @@ void initBWifi(bool resetWifi){
   server.addHandler(&events);
 
   if (!wifiConfig.ota_username) {
-    AsyncElegantOTA.begin(&server);
+    ElegantOTA.begin(&server);
   } else {
-    AsyncElegantOTA.begin(&server, wifiConfig.ota_username, wifiConfig.ota_password);
+    ElegantOTA.begin(&server, wifiConfig.ota_username, wifiConfig.ota_password);
   }
 
   server.begin();

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ You will need to install a board support package for your ESP32. Additionally th
 
 * https://github.com/tzapu/WiFiManager
 * https://github.com/knolleary/pubsubclient
-* https://github.com/ayushsharma82/AsyncElegantOTA
+* https://github.com/ayushsharma82/ElegantOTA
 * https://github.com/me-no-dev/ESPAsyncWebServer
 * https://github.com/me-no-dev/AsyncTCP/archive
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -5,8 +5,7 @@ src_dir = Bluetti_ESP32
 lib_deps =
     https://github.com/tzapu/WiFiManager/archive/refs/tags/v2.0.15-rc.1.zip
     PubSubClient@^2.8.0
-    https://github.com/me-no-dev/ESPAsyncWebServer/archive/master.zip
-    AsyncElegantOTA@^2.2.7
+    ElegantOTA@^3.1.4
     h2zero/NimBLE-Arduino @ ^1.4.1
     adafruit/Adafruit SSD1306@^2.5.7
     adafruit/Adafruit GFX Library @ ^1.11.5
@@ -21,5 +20,5 @@ framework = arduino
 board = esp32dev
 board_build.partitions = min_spiffs.csv
 monitor_speed = 115200
-
-
+build_flags=-DELEGANTOTA_USE_ASYNC_WEBSERVER=1
+lib_compat_mode = strict


### PR DESCRIPTION
Hi,
Just found your project _(thank you very much!)_ but platformio (`pio run`)  can't  find `AsyncElegantOTA.h` when compiling.

I guess the reason is [AsyncElegantOTA](https://github.com/ayushsharma82/AsyncElegantOTA) has been deprecated in favor of [ElegantOTA](https://github.com/ayushsharma82).

This PR makes the project use ElegantOTA instead of AsyncElegantOTA.

Tested:

- [X] the project builds fine
- [X] webinterface works
- [X] adding the device to the own network works
- [X] mqtt connection works

~There is no connection to my AC300 recognized (bluetooth scans on other devices see it), but that is probably not related to the code change _(will test with my AC200max, which is currently not nearby, soonish)_~

EDIT: the esp32 was too far away, it works as expected!